### PR TITLE
Change the name to be included in INSTALLED_APPS

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -46,6 +46,13 @@ can migrate.
   replace it by `cid.apps.CidAppConfig`. If you did not, add the
   latter.
 
+* |backward-incompatible| Drop compatibility with
+  ``MIDDLEWARE_CLASSES``.  You should use the ``MIDDLEWARE``
+  setting. If you already did, no change is necessary.
+
+  If you really must use the old ``MIDDLEWARE_CLASSES`` setting,
+  include ``CidOldStyleMiddleware`` instead of ``CidMiddleware``.
+
 
 
 .. role:: raw-html(raw)

--- a/cid/middleware.py
+++ b/cid/middleware.py
@@ -1,17 +1,16 @@
 from django.conf import settings
-from django.utils.deprecation import MiddlewareMixin
 
 from .locals import set_cid, get_cid
 
 
-class CidMiddleware(MiddlewareMixin):
+class CidMiddleware:
     """
     Middleware class to extract the correlation id from incoming headers
     and add them to outgoing headers
     """
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, get_response):
+        self.get_response = get_response
         self.cid_request_header = getattr(
             settings, 'CID_HEADER', 'X_CORRELATION_ID'
         )
@@ -19,15 +18,40 @@ class CidMiddleware(MiddlewareMixin):
             settings, 'CID_RESPONSE_HEADER', self.cid_request_header
         )
 
-    def process_request(self, request):
+    def _process_request(self, request):
         cid = request.META.get(self.cid_request_header, None)
         if cid is None:
             cid = get_cid()
         request.correlation_id = cid
         set_cid(cid)
+        return request
 
-    def process_response(self, request, response):
+    def _process_response(self, response):
         cid = get_cid()
         if cid and self.cid_response_header:
             response[self.cid_response_header] = cid
         return response
+
+    def __call__(self, request):
+        request = self._process_request(request)
+        response = self.get_response(request)
+        return self._process_response(response)
+
+
+class CidOldStyleMiddleware(CidMiddleware):
+    """Support for the old ``MIDDLEWARE_CLASSES`` setting."""
+
+    def __init__(self):
+        print('middleware init')
+        # `get_response` is only used in `CidMiddleware.__call__`,
+        # which is not called when using `MIDDLEWARE_CLASSES`.
+        super().__init__(get_response='dummy')
+
+    def process_request(self, request):
+        self._process_request(request)
+        # We must return None otherwise Django thinks it's the
+        # response.
+        return None
+
+    def process_response(self, request, response):
+        return self._process_response(response)

--- a/conftest.py
+++ b/conftest.py
@@ -36,16 +36,6 @@ def pytest_configure():
             'cid',
         ],
 
-        MIDDLEWARE_CLASSES=(
-            'django.contrib.sessions.middleware.SessionMiddleware',
-            'django.middleware.common.CommonMiddleware',
-            'django.middleware.csrf.CsrfViewMiddleware',
-            'django.contrib.auth.middleware.AuthenticationMiddleware',
-            'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
-            'django.contrib.messages.middleware.MessageMiddleware',
-            'django.middleware.clickjacking.XFrameOptionsMiddleware',
-        ),
-
         STATICFILES_DIRS=(location('static/'),),
         STATIC_ROOT=location('public'),
         STATIC_URL='/static/',

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -7,16 +7,27 @@ Usage
 Django Correlation Ids have a number of options for usage covering logging,
 SQL comments, and a template context processor.
 
-All of these rely on the usage of a piece of middleware. To configure the
-middleware simply add the following to your list of MIDDLEWARE_CLASSES in
-your settings file:
+All of these rely on the usage of a piece of middleware. To configure
+the middleware, simply add the following to ``MIDDLEWARE`` in your
+settings file:
 
 .. code-block:: python
 
-    MIDDLEWARE_CLASSES = (
+    MIDDLEWARE = (
         'cid.middleware.CidMiddleware',
-        # other middleware
+        # other middlewares
     )
+
+If you really must use the old ``MIDDLEWARE_CLASSES`` setting,
+include the old-style class instead:
+
+.. code-block:: python
+
+    MIDDLEWARE = (
+        'cid.middleware.CidOldStyleMiddleware',
+        # other middlewares
+    )
+
 
 By default the middleware will look for the correlation id in an incoming
 request header called ``X_CORRELATION_ID``. An alternative header name can be

--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -36,7 +36,7 @@ INSTALLED_APPS = (
     'django.contrib.staticfiles',
 )
 
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE = (
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',


### PR DESCRIPTION
`default_app_config` is deprecated. Django documentation says:

    `default_app_config` allows applications that predate Django 1.7
    such as `django.contrib.admin` to opt-in to `AppConfig` features
    without requiring users to update their `INSTALLED_APPS`.

    New applications should avoid `default_app_config`. Instead they
    should require the dotted path to the appropriate `AppConfig`
    subclass to be configured explicitly in `INSTALLED_APPS`.

This change is NOT backward compatible. However, adding the app to
`INSTALLED_APPS` was not required. So users that did not follow the
installation instructions won't be hit.