### PR TITLE
sandbox: Fix tests against sandbox

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -6,6 +6,7 @@ from django.core.files import temp as tempfile
 
 
 sys.path.insert(0, os.path.dirname(__file__))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'sandbox'))
 
 
 def location(x):

--- a/sandbox/testapp/urls.py
+++ b/sandbox/testapp/urls.py
@@ -4,5 +4,6 @@ from . import views
 
 
 urlpatterns = (
+    url(r'ok', views.ok, name='ok'),
     url(r'', views.testit, name='testit'),
 )

--- a/sandbox/testapp/views.py
+++ b/sandbox/testapp/views.py
@@ -1,6 +1,7 @@
 import logging
 
 from django.db import connection
+from django.http import HttpResponse
 from django.shortcuts import render
 
 from testapp.models import Item
@@ -16,3 +17,8 @@ def testit(request):
         'sql_query': connection.queries[0]['sql'],
     }
     return render(request, 'testapp/testit.html', context)
+
+
+def ok(request):
+    """A simple view for integration tests."""
+    return HttpResponse('ok')

--- a/sandbox/urls.py
+++ b/sandbox/urls.py
@@ -1,9 +1,8 @@
+from django.conf.urls import include, url
 from django.contrib import admin
-from django.urls import include, path
-from django.conf.urls import include
 
 
 urlpatterns = (
-    path('admin/', admin.site.urls),
-    path('', include('testapp.urls')),
+    url('admin/', admin.site.urls),
+    url('', include('testapp.urls')),
 )

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -96,7 +96,7 @@ class TestCidMiddleware(TestCase):
 class TestIntegration(TestCase):
 
     def _test_integration(self):
-        url = reverse('testit')  # comes from sandbox/testapp
+        url = reverse('ok')  # comes from sandbox/testapp
 
         # A request without any correlation id
         response = self.client.get(url)


### PR DESCRIPTION
1. Inject `sandbox` in `sys.path`, otherwise we get this error:

    `ModuleNotFoundError: No module named 'testapp'`

   There probably is a better way to do this...

2. Add a more simple view. Oddly, the `TestIntegration` case fails
   because `connection.queries` is empty when running the `testit`
   view. I don't have the time to debug right now, so let's use
   a boringly simple view instead.