### PR TITLE
setup.py: Fix long_description

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,10 +18,12 @@
 
 import datetime
 import os
+import sys
 
 import cid
 
 
+sys.path.insert(0, '.')
 os.environ['DJANGO_SETTINGS_MODULE'] = 'sandbox.settings'
 
 

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -1,4 +1,4 @@
-# `docutils` is needed to check for `setup.py check --restructuredtext`
-docutils
+# `readme_renderer` is needed to check for `setup.py check --restructuredtext`
 isort
 pylint
+readme_renderer

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,26 @@
 from setuptools import setup, find_packages
 
 
+def clean_history(history):
+    # PyPI does not allow the `raw` directive. We'll laboriously
+    # replace it. Hang tight, it's going to be ugly.
+    history = history.replace('|backward-incompatible|', '**backward incompatible:** ')
+    lines = []
+    for line in history.split('\n'):
+        if line.startswith('.. role:: raw-html'):
+            break
+        lines.append(line)
+    return '\n'.join(lines)
+
+
 readme = open('README.rst').read()
-history = open('HISTORY.rst').read().replace('.. :changelog:', '')
+changelog = clean_history(open('HISTORY.rst').read())
 
 setup(
     name='django-cid',
     version='1.1.dev0',
     description="""Correlation IDs in Django for debugging requests""",
-    long_description=readme + '\n\n' + history,
+    long_description=readme + '\n\n' + changelog,
     author='Snowball One',
     author_email='opensource+django-cid@polyconseil.fr',
     maintainer="Polyconseil",


### PR DESCRIPTION
PyPI does not allow the `raw` directive in the long description. I
want to keep the "backward-incompatible" tag in the HTML
documentation, it really stands out. So let's tweak the contents of
the HISTORY.txt file instead.

If you see this commit message in a few months when it breaks, here is
my message: I did not really think that it would not break. Sorry!