### PR TITLE
cid: Allow to concatenate upstream and local correlation ids

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,7 +4,8 @@ History
 1.1 (unreleased)
 ++++++++++++++++
 
-- Nothing changed yet.
+- Allow to concatenate an upstream correlation id with a
+  locally-generated one, with a new ``CID_CONCATENATE_IDS`` setting.
 
 
 1.0 (2018-10-01)

--- a/cid/middleware.py
+++ b/cid/middleware.py
@@ -23,6 +23,11 @@ class CidMiddleware:
         cid = request.META.get(self.cid_request_header, None)
         if cid is None:
             cid = get_cid()
+        elif (
+                getattr(settings, 'CID_CONCATENATE_IDS', False)
+                and getattr(settings, 'CID_GENERATE', False)
+        ):
+            cid = '%s, %s' % (cid, get_cid())
         request.correlation_id = cid
         set_cid(cid)
         return request

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -81,6 +81,22 @@ setting:
     in front of Django, the latter, sanitized value should be used in
     the settings.
 
+If a correlation id is provided upstream (e.g. "1234"), it is possible
+to concatenate it with a newly generated one. The cid will then look
+like ``1234, 1aa38e4e-89c6-4655-9b8e-38ca349da017``. To do so, use the
+following settings:
+
+.. code-block:: python
+
+    CID_GENERATE = True
+    CID_CONCATENATE_IDS = True
+
+This is useful when you use a service-oriented architecture and want
+to be able to follow a request amongst all systems (by looking at logs
+that have the first correlation id that was set upstream), and also on
+a particular system (by looking at logs that have the id added by the
+system itself).
+
 
 Inclusion of the correlation id in the response
 -----------------------------------------------


### PR DESCRIPTION
This is useful when you use a service-oriented architecture and want
to be able to follow a request amongst all systems (by looking at logs
that have the first correlation id that was set upstream), and also on
a particular system (by looking at logs that have the id added by the
system itself).