### PR TITLE
middleware: Don't reuse correlation id across requests processed by the same thread

### DIFF
--- a/cid/locals.py
+++ b/cid/locals.py
@@ -12,11 +12,11 @@ def set_cid(cid):
     setattr(_thread_locals, 'CID', cid)
 
 
-def clear_cid():
+def _clear_cid():
     """Clear the correlation id from our storage.
 
-    If you use the middleware, you probably should never have to call
-    this function. It is to be used only.
+    This is an internal function that is likely to be removed in a
+    future version.
     """
     set_cid(None)
 

--- a/cid/locals.py
+++ b/cid/locals.py
@@ -12,6 +12,15 @@ def set_cid(cid):
     setattr(_thread_locals, 'CID', cid)
 
 
+def clear_cid():
+    """Clear the correlation id from our storage.
+
+    If you use the middleware, you probably should never have to call
+    this function. It is to be used only.
+    """
+    set_cid(None)
+
+
 def get_cid():
     """Return the currently set correlation id (if any).
 

--- a/cid/middleware.py
+++ b/cid/middleware.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 
-from cid.locals import clear_cid
+from cid.locals import _clear_cid
 from cid.locals import get_cid
 from cid.locals import set_cid
 
@@ -21,7 +21,7 @@ class CidMiddleware:
         )
 
     def _process_request(self, request):
-        clear_cid()
+        _clear_cid()
         cid = request.META.get(self.cid_request_header, None)
         if cid is None:
             cid = get_cid()

--- a/cid/middleware.py
+++ b/cid/middleware.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 
+from cid.locals import clear_cid
 from cid.locals import get_cid
 from cid.locals import set_cid
 
@@ -20,6 +21,7 @@ class CidMiddleware:
         )
 
     def _process_request(self, request):
+        clear_cid()
         cid = request.META.get(self.cid_request_header, None)
         if cid is None:
             cid = get_cid()
@@ -49,7 +51,6 @@ class CidOldStyleMiddleware(CidMiddleware):
     """Support for the old ``MIDDLEWARE_CLASSES`` setting."""
 
     def __init__(self):
-        print('middleware init')
         # `get_response` is only used in `CidMiddleware.__call__`,
         # which is not called when using `MIDDLEWARE_CLASSES`.
         super().__init__(get_response='dummy')

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -57,13 +57,21 @@ class TestCidMiddleware(TestCase):
     @override_settings(CID_GENERATE=True)
     @mock.patch('uuid.uuid4')
     def test_generate_cid(self, uuid4):
-        uuid4.return_value = 'generated-cid'
+        uuid4.return_value = 'first-cid'
         request = make_request(cid=None)
         middleware = CidMiddleware(get_response=get_response)
         response = middleware(request)
-        self.assertEqual(request.correlation_id, 'generated-cid')
-        self.assertEqual(cid.locals.get_cid(), 'generated-cid')
-        self.assertEqual(response['X_CORRELATION_ID'], 'generated-cid')
+        self.assertEqual(request.correlation_id, 'first-cid')
+        self.assertEqual(cid.locals.get_cid(), 'first-cid')
+        self.assertEqual(response['X_CORRELATION_ID'], 'first-cid')
+
+        uuid4.return_value = 'second-cid'
+        request = make_request(cid=None)
+        middleware = CidMiddleware(get_response=get_response)
+        response = middleware(request)
+        self.assertEqual(request.correlation_id, 'second-cid')
+        self.assertEqual(cid.locals.get_cid(), 'second-cid')
+        self.assertEqual(response['X_CORRELATION_ID'], 'second-cid')
 
     @override_settings(CID_GENERATE=True, CID_CONCATENATE_IDS=True)
     @mock.patch('uuid.uuid4')


### PR DESCRIPTION
This is a partial revert of 4476392b4e6c0d9f9a38074359cb139f6612f77b.

That commit introduced a bug that caused the correlation id to persist
across requests if the same thread was used to process them (which is
the case with uWSGI for example). All these requests had the same
correlation id.

The intention of the reverted commit is lost: we cannot use `get_cid`
anymore when the middleware is not used.

A better fix would probably be to get rid of the `_process_request()`
part of the middleware. Instead, we could register a signal handler
for "request_started" that would set the correlation id. That way, we
could greatly simplify the middleware and make it only set the
response header if configured.