### PR TITLE
cid: Don't reuse correlation id across requests processed by the same thread

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,7 +4,9 @@ History
 1.2 (unreleased)
 ++++++++++++++++
 
-- Nothing changed yet.
+- **bugfix:** Fix bug (introduced in version 1.0) that caused the
+  correlation id to be reused across all requests that were processed
+  by the same thread.
 
 
 1.1 (2018-10-01)

--- a/cid/locals.py
+++ b/cid/locals.py
@@ -17,9 +17,24 @@ def get_cid():
 
     If no correlation id has been set and ``CID_GENERATE`` is enabled
     in the settings, a new correlation id is set and returned.
+
+    FIXME (dbaty): in version 2, just `return getattr(_thread_locals, 'CID', None)`
+    We want the simplest thing here and let `generate_new_cid` do the job.
     """
     cid = getattr(_thread_locals, 'CID', None)
     if cid is None and getattr(settings, 'CID_GENERATE', False):
         cid = str(uuid.uuid4())
         set_cid(cid)
     return cid
+
+
+def generate_new_cid(upstream_cid=None):
+    """Generate a new correlation id, possibly based on the given one."""
+    if upstream_cid is None:
+        return str(uuid.uuid4()) if getattr(settings, 'CID_GENERATE', False) else None
+    if (
+            getattr(settings, 'CID_CONCATENATE_IDS', False)
+            and getattr(settings, 'CID_GENERATE', False)
+    ):
+        return '%s, %s' % (upstream_cid, str(uuid.uuid4()))
+    return upstream_cid

--- a/cid/middleware.py
+++ b/cid/middleware.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 
+from cid.locals import generate_new_cid
 from cid.locals import get_cid
 from cid.locals import set_cid
 
@@ -20,14 +21,8 @@ class CidMiddleware:
         )
 
     def _process_request(self, request):
-        cid = request.META.get(self.cid_request_header, None)
-        if cid is None:
-            cid = get_cid()
-        elif (
-                getattr(settings, 'CID_CONCATENATE_IDS', False)
-                and getattr(settings, 'CID_GENERATE', False)
-        ):
-            cid = '%s, %s' % (cid, get_cid())
+        upstream_cid = request.META.get(self.cid_request_header, None)
+        cid = generate_new_cid(upstream_cid)
         request.correlation_id = cid
         set_cid(cid)
         return request

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
-[wheel]
+[bdist_wheel]
 universal = 1
+
+[zest.releaser]
+create-wheel = yes


### PR DESCRIPTION
This is a partial revert of 4476392.

That commit introduced a bug that caused the correlation id to persist
across requests if the same thread was used to process them (which is
the case with uWSGI for example). All these requests had the same
correlation id.

The intention of the reverted commit is not lost. If you don't use the
middleware, you should now call `cid.locals.generate_new_cid` before
trying to call `get_cid`.