### PR TITLE
Support contextvars on python>=3.7

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,7 +4,8 @@ History
 2.2 (unreleased)
 ++++++++++++++++
 
-- Nothing changed yet.
+- Under Python 3.7 and later, use context variables (with the contextvars module)
+  instead of a thread-local variable to avoid state bleeding in concurrent code.
 
 
 2.1 (2020-06-22)

--- a/cid/locals/__init__.py
+++ b/cid/locals/__init__.py
@@ -1,0 +1,15 @@
+try:
+    # ContextVar is available since python 3.7,
+    # oldest python version keep using thread_local
+    from .context import set_cid, get_cid  # noqa
+except ImportError:
+    from .thread_local import set_cid, get_cid  # noqa
+
+from .base import generate_new_cid
+
+
+__all__ = (
+    'generate_new_cid',
+    'set_cid',
+    'get_cid',
+)

--- a/cid/locals/__init__.py
+++ b/cid/locals/__init__.py
@@ -1,6 +1,6 @@
 try:
     # ContextVar is available since python 3.7,
-    # oldest python version keep using thread_local
+    # Older versions of Python will use thread_local
     from .context import set_cid, get_cid  # noqa
 except ImportError:
     from .thread_local import set_cid, get_cid  # noqa

--- a/cid/locals/base.py
+++ b/cid/locals/base.py
@@ -1,0 +1,20 @@
+import uuid
+
+from django.conf import settings
+
+
+def generate_new_cid(upstream_cid=None):
+    """Generate a new correlation id, possibly based on the given one."""
+    if upstream_cid is None:
+        return build_cid() if getattr(settings, 'CID_GENERATE', False) else None
+    if (
+            getattr(settings, 'CID_CONCATENATE_IDS', False)
+            and getattr(settings, 'CID_GENERATE', False)
+    ):
+        return '%s, %s' % (upstream_cid, build_cid())
+    return upstream_cid
+
+
+def build_cid():
+    """Build a new cid"""
+    return str(getattr(settings, 'CID_GENERATOR', uuid.uuid4)())

--- a/cid/locals/context.py
+++ b/cid/locals/context.py
@@ -1,0 +1,23 @@
+from contextvars import ContextVar
+
+from django.conf import settings
+
+from .base import build_cid
+
+
+correlation_id = ContextVar('correlation_id', default=None)
+
+
+def set_cid(cid):
+    """Set the correlation id on the context."""
+    correlation_id.set(cid)
+
+
+def get_cid():
+    """Return the currently set correlation id (if any).
+    """
+    cid = correlation_id.get()
+    if cid is None and getattr(settings, 'CID_GENERATE', False):
+        cid = build_cid()
+        set_cid(cid)
+    return cid

--- a/cid/locals/thread_local.py
+++ b/cid/locals/thread_local.py
@@ -1,7 +1,8 @@
 from threading import local
-import uuid
 
 from django.conf import settings
+
+from .base import build_cid
 
 
 _thread_locals = local()
@@ -23,23 +24,6 @@ def get_cid():
     """
     cid = getattr(_thread_locals, 'CID', None)
     if cid is None and getattr(settings, 'CID_GENERATE', False):
-        cid = _build_cid()
+        cid = build_cid()
         set_cid(cid)
     return cid
-
-
-def generate_new_cid(upstream_cid=None):
-    """Generate a new correlation id, possibly based on the given one."""
-    if upstream_cid is None:
-        return _build_cid() if getattr(settings, 'CID_GENERATE', False) else None
-    if (
-            getattr(settings, 'CID_CONCATENATE_IDS', False)
-            and getattr(settings, 'CID_GENERATE', False)
-    ):
-        return '%s, %s' % (upstream_cid, _build_cid())
-    return upstream_cid
-
-
-def _build_cid():
-    """Build a new cid"""
-    return str(getattr(settings, 'CID_GENERATOR', uuid.uuid4)())

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -1,4 +1,4 @@
 # `readme_renderer` is needed to check for `setup.py check --restructuredtext`
-isort
+isort~=4.3
 pylint
 readme_renderer

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -1,4 +1,4 @@
 # `readme_renderer` is needed to check for `setup.py check --restructuredtext`
-isort~=4.3
+isort
 pylint
 readme_renderer

--- a/tests/test_context_processors.py
+++ b/tests/test_context_processors.py
@@ -10,7 +10,7 @@ class TestContextProcessor(TestCase):
     @mock.patch('cid.context_processors.get_cid')
     def test_cid_added(self, get_cid):
         get_cid.return_value = 'a-text-cid'
-        self.assertEquals(
+        self.assertEqual(
             {'correlation_id': 'a-text-cid'},
             cid_context_processor(mock.Mock())
         )
@@ -18,4 +18,4 @@ class TestContextProcessor(TestCase):
     @mock.patch('cid.context_processors.get_cid')
     def test_cid_not_added_if_not_present(self, get_cid):
         get_cid.return_value = None
-        self.assertEquals({}, cid_context_processor(mock.Mock()))
+        self.assertEqual({}, cid_context_processor(mock.Mock()))


### PR DESCRIPTION
prevent correlation_id state from bleeding to other code unexpectedly, when used in concurrent code. 