### PR TITLE
docs: Remove installation of database libraries

### DIFF
--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -4,7 +4,3 @@ sphinx
 sphinx_rtd_theme
 
 django
-
-cx_oracle
-mysqlclient
-psycopg2


### PR DESCRIPTION
We used to build a full API documentation of internals (which required
database libraries), but we stopped doing that since 02d027fd8e6eea6.
We therefore no longer need these dependencies to build the docs.