### PR TITLE
Adds a setting to define the correlation id placement injected in the SQL statement.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -21,6 +21,9 @@ those versions, you should pin ``django-cid < 3``.
 - |backward-incompatible| Drop support of Django 3.0 and prior
   versions. Only Django 3.1 and later are supported.
 
+- Add `CID_SQL_STATEMENT_TEMPLATE` setting to customize the position
+  of the correlation relative to the original SQL statement.
+  Contributed by Cauê Garcia Polimanti (@CaueP).
 
 2.3 (2022-06-13)
 ++++++++++++++++

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -244,6 +244,15 @@ a string with a ``cid`` format parameter:
     CID_SQL_COMMENT_TEMPLATE = 'correlation={cid}'
 
 
+Also, you may change the position of the correlation id injected in
+the statement by defining a ``CID_SQL_STATEMENT_TEMPLATE`` that is
+a string with a ``cid`` and a ``sql`` format parameter:
+
+.. code-block:: python
+
+    CID_SQL_STATEMENT_TEMPLATE = '/* {cid} */\n{sql}'
+
+
 Inclusion of the correlation id in templates
 --------------------------------------------
 

--- a/src/cid/cursor.py
+++ b/src/cid/cursor.py
@@ -4,6 +4,7 @@ from .locals import get_cid
 
 
 DEFAULT_CID_SQL_COMMENT_TEMPLATE = 'cid: {cid}'
+DEFAULT_SQL_STATEMENT_TEMPLATE = '/* {cid} */\n{sql}'
 
 
 class CidCursorWrapper:
@@ -31,12 +32,16 @@ class CidCursorWrapper:
         cid_sql_template = getattr(
             settings, 'CID_SQL_COMMENT_TEMPLATE', DEFAULT_CID_SQL_COMMENT_TEMPLATE
         )
+        sql_statement_template = getattr(
+            settings, 'CID_SQL_STATEMENT_TEMPLATE', DEFAULT_SQL_STATEMENT_TEMPLATE
+        )
         cid = get_cid()
         if not cid:
             return sql
         cid = cid.replace('/*', r'\/\*').replace('*/', r'\*\/')
         cid = cid_sql_template.format(cid=cid)
-        return f"/* {cid} */\n{sql}"
+        statement = sql_statement_template.format(cid=cid, sql=sql)
+        return statement
 
     # The following methods cannot be implemented in __getattr__, because the
     # code must run when the method is invoked, not just when it is accessed.

--- a/tests/test_cursor.py
+++ b/tests/test_cursor.py
@@ -33,6 +33,16 @@ class TestCidCursor(TestCase):
             self.cursor_wrapper.add_comment("SELECT 1;")
         )
 
+    @override_settings(CID_SQL_STATEMENT_TEMPLATE='{sql}\n/* {cid} */')
+    @mock.patch('cid.cursor.get_cid')
+    def test_adds_comment_with_statement_template_setting_overriden(self, get_cid):
+        get_cid.return_value = 'testing-cursor-after-sql-statement'
+        expected = "SELECT 1;\n/* cid: testing-cursor-after-sql-statement */"
+        self.assertEqual(
+            expected,
+            self.cursor_wrapper.add_comment("SELECT 1;")
+        )
+
     @mock.patch('cid.cursor.get_cid')
     def test_no_comment_when_cid_is_none(self, get_cid):
         get_cid.return_value = None


### PR DESCRIPTION
Adds a setting to define the correlation id placement injected in the SQL statement.

The main motivation for this was due to OpenTelemetry instrumentation for psycopg2 which uses the first word to define which database operation is being performed and the operation was being defined to the comment marker `/*` due to the comment in the beginning.