### PR TITLE
fix: Replace use of deprecated `pkg_resources` by `importlib`

### DIFF
--- a/src/cid/__init__.py
+++ b/src/cid/__init__.py
@@ -1,4 +1,4 @@
-import pkg_resources
+import importlib.metadata
 
 
-__version__ = pkg_resources.get_distribution('django-cid').version
+__version__ = importlib.metadata.version('django-cid')


### PR DESCRIPTION
`pkg_resources` is deprecated (https://setuptools.pypa.io/en/latest/pkg_resources.html).

Closes #65.